### PR TITLE
ci: remove RHEL 4 sync

### DIFF
--- a/yum-repos.conf
+++ b/yum-repos.conf
@@ -265,17 +265,6 @@ testing-tag = eng-fedora-31-candidate
 rhts = rhts-python rhts-test-env rhts-devel
 beaker = beaker-common beaker-client
 
-[harness-rhel4]
-name = harness
-testing-name = harness-testing
-distro = RedHatEnterpriseLinux4
-source = brew
-arches = i386 x86_64 ia64 ppc s390 s390x
-tag = beaker-harness-rhel-4
-testing-tag = beaker-harness-rhel-4-candidate
-all-packages = true
-excluded-rpms = rhts-devel
-
 [harness-rhel5]
 name = harness
 testing-name = harness-testing


### PR DESCRIPTION
We are no longer support RHEL4.
Configuration can be removed.

Signed-off-by: Martin Styk <mastyk@redhat.com>