### PR TITLE
ci: sync rhts artifacts for RHEL8

### DIFF
--- a/yum-repos.conf
+++ b/yum-repos.conf
@@ -235,6 +235,7 @@ testing-tag = beaker-server-rhel-8-candidate
 [client-rhel8.packages]
 beaker = beaker-common beaker-client
 beakerlib = beakerlib beakerlib-vim-syntax
+rhts = rhts-python rhts-test-env rhts-devel
 
 [client-f30]
 name = client


### PR DESCRIPTION
Until now we provided new RHTS (5.0) only to F30+.
This patch is adding syncing for RHEL8 (Python3).
Signed-off-by: Martin Styk <mastyk@redhat.com>