### PR TITLE
CI: Add packages for Fedora Rawhide (currently F32) and use signed builds for F31

### DIFF
--- a/yum-repos.conf
+++ b/yum-repos.conf
@@ -259,8 +259,7 @@ source = brew
 arches = x86_64
 tag = eng-fedora-31
 testing-tag = eng-fedora-31-candidate
-# DEVOPSA-7256
-#signed = true
+signed = true
 
 [client-f31.packages]
 rhts = rhts-python rhts-test-env rhts-devel

--- a/yum-repos.conf
+++ b/yum-repos.conf
@@ -265,6 +265,20 @@ signed = true
 rhts = rhts-python rhts-test-env rhts-devel
 beaker = beaker-common beaker-client
 
+[client-frawhide]
+name = client
+testing-name = client-testing
+distro = Fedorarawhide
+source = brew
+arches = x86_64
+tag = eng-fedora-32
+testing-tag = eng-fedora-32-candidate
+signed = true
+
+[client-frawhide.packages]
+rhts = rhts-python rhts-test-env rhts-devel
+beaker = beaker-common beaker-client
+
 [harness-rhel5]
 name = harness
 testing-name = harness-testing


### PR DESCRIPTION
- Rawhide builds for Beaker client (27) and RHTS (5)
- DEVOPSA-7256 resolved. We can use builds with signatures again