### PR TITLE
ci: add beaker packages for fedora 32

### DIFF
--- a/yum-repos.conf
+++ b/yum-repos.conf
@@ -269,6 +269,21 @@ signed = true
 rhts = rhts-python rhts-test-env rhts-devel
 beaker = beaker-common beaker-client
 
+[client-f32]
+name = client
+testing-name = client-testing
+distro = Fedora32
+source = brew
+arches = x86_64
+tag = eng-fedora-32
+testing-tag = eng-fedora-32-candidate
+signed = true
+
+[client-f32.packages]
+rhts = rhts-python rhts-test-env rhts-devel
+beaker = beaker-common beaker-client
+
+# RCM-77182 | chroot for F33 doesn't exist yet
 [client-frawhide]
 name = client
 testing-name = client-testing


### PR DESCRIPTION
Provide packages for Beaker in F32.
Rawhide can't be moved to new chroot, because we don't have it yet.
Signed-off-by: Martin Styk <mastyk@redhat.com>