### PR TITLE
ci: enable fedora rawhide multiarch

### DIFF
--- a/yum-repos.conf
+++ b/yum-repos.conf
@@ -375,12 +375,7 @@ name = harness
 testing-name = harness-testing
 distro = Fedorarawhide
 source = brew
-# BST-312 closed, however, now it is not possible
-# to build rawhide due to changes in compression
-# from xz to zstd
-# BREW-3558
-#arches = x86_64 i686 ppc64le aarch64 s390x
-arches = x86_64
+arches = x86_64 ppc64le aarch64 s390x
 tag = eng-fedora-31
 testing-tag = eng-fedora-31-candidate
 


### PR DESCRIPTION
Currently, we are feeding Fedora 31 builds to Rawhide (because F32+ is broken from Restraint side).
So let's enable same arches as we have for F31.
Signed-off-by: Martin Styk <mastyk@redhat.com>