### PR TITLE
Enable Fedora 32 and Fedora 33 restraint builds

### DIFF
--- a/yum-repos.conf
+++ b/yum-repos.conf
@@ -369,14 +369,28 @@ beaker-system-scan = beaker-system-scan beaker-system-scan-debuginfo beaker-syst
 lshw = lshw lshw-gui lshw-debuginfo lshw-debugsource lshw-gui-debuginfo
 restraint = restraint restraint-client restraint-client-debuginfo restraint-debuginfo restraint-debugsource restraint-rhts
 
+[harness-f32]
+name = harness
+testing-name = harness-testing
+distro = Fedora32
+source = brew
+arches = x86_64 ppc64le s390x
+tag = eng-fedora-32
+testing-tag = eng-fedora-32-candidate
+
+[harness-f32.packages]
+beaker-system-scan = beaker-system-scan beaker-system-scan-debuginfo beaker-system-scan-debugsource
+lshw = lshw lshw-gui lshw-debuginfo lshw-debugsource lshw-gui-debuginfo
+restraint = restraint restraint-client restraint-client-debuginfo restraint-debuginfo restraint-debugsource restraint-rhts
+
 [harness-frawhide]
 name = harness
 testing-name = harness-testing
 distro = Fedorarawhide
 source = brew
-arches = x86_64 ppc64le aarch64 s390x
-tag = eng-fedora-31
-testing-tag = eng-fedora-31-candidate
+arches = x86_64 ppc64le s390x
+tag = eng-fedora-33
+testing-tag = eng-fedora-33-candidate
 
 [harness-frawhide.packages]
 beaker-system-scan = beaker-system-scan beaker-system-scan-debuginfo beaker-system-scan-debugsource


### PR DESCRIPTION
At this moment Rawhide was generated from Fedora 31.
Instead of that, we should use dedicated buildroot as we can build Restraint in Fedora again.

Aarch64 is disabled as we don't have any resources for building. This may change in the future when new aarch64 machines are available.

Signed-off-by: Martin Styk <mastyk@redhat.com>