### PR TITLE
ci: add support for aarch64 builds in restraint

### DIFF
--- a/yum-repos.conf
+++ b/yum-repos.conf
@@ -374,7 +374,7 @@ name = harness
 testing-name = harness-testing
 distro = Fedora32
 source = brew
-arches = x86_64 ppc64le s390x
+arches = x86_64 ppc64le s390x aarch64
 tag = eng-fedora-32
 testing-tag = eng-fedora-32-candidate
 
@@ -388,7 +388,7 @@ name = harness
 testing-name = harness-testing
 distro = Fedorarawhide
 source = brew
-arches = x86_64 ppc64le s390x
+arches = x86_64 ppc64le s390x aarch64
 tag = eng-fedora-33
 testing-tag = eng-fedora-33-candidate
 


### PR DESCRIPTION
Our Ampere HR330a finally brings us some results.
It is used as a builder for our Restraint builds for aarch64.
Signed-off-by: Martin Styk <mastyk@redhat.com>