### PR TITLE
chore: refactor inline css and javascript

### DIFF
--- a/download.html
+++ b/download.html
@@ -8,15 +8,6 @@
     <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
   <link href="style.css" rel="stylesheet" type="text/css"/>
-  <style type="text/css">
-    .repolink {
-        background-position: left top;
-        background-repeat: no-repeat;
-        padding-left: 74px;
-        background-image: url("images/package.png");
-        line-height: 54px;
-    }
-  </style>
 </head>
 <body>
 <div class="header">

--- a/generate-releases-index.py
+++ b/generate-releases-index.py
@@ -33,41 +33,7 @@ html_template = MarkupTemplate(u'''
     <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
   <link href="../style.css" rel="stylesheet" type="text/css"/>
-  <style type="text/css">
-    article {
-        margin-bottom: 1em;
-    }
-    .release h2 {
-        display: inline-block;
-        font-size: 1em;
-    }
-    .date:before, .relnotes-link:before, .changelog-link:before {
-        content: "·";
-        margin-right: 0.3em;
-    }
-    .date, .relnotes-link, .changelog-link {
-        display: inline-block;
-        margin-left: 0.4em;
-    }
-    .download {
-        margin: 0.5em 0;
-        background-position: left top;
-        background-repeat: no-repeat;
-        padding-left: 74px;
-    }
-    .download.tarball {
-        background-image: url("../images/package.png");
-        min-height: 54px;
-    }
-    .download.patch {
-        background-image: url("../images/patch.png");
-        min-height: 64px;
-    }
-    .hash {
-        white-space: nowrap;
-        font-size: 0.9em;
-    }
-  </style>
+  <link href="../releases.css" rel="stylesheet" type="text/css"/>
   <link rel="profile" href="http://microformats.org/profile/hatom" />
   <link rel="alternate" type="application/atom+xml" title="Atom feed" href="index.atom" />
 </head>

--- a/gpg/index.html
+++ b/gpg/index.html
@@ -8,16 +8,6 @@
     <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
   <link href="../style.css" rel="stylesheet" type="text/css" />
-  <style type="text/css">
-    .gpgkey {
-        margin: 0.5em 0;
-        background-position: left top;
-        background-repeat: no-repeat;
-        padding-left: 74px;
-        min-height: 64px;
-        background-image: url("../images/certificate.png");
-    }
-  </style>
 </head>
 <body>
 <div class="header">

--- a/index.html
+++ b/index.html
@@ -8,28 +8,6 @@
     <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
   <![endif]-->
   <link href="style.css" rel="stylesheet" type="text/css"/>
-  <style>
-    .slogan {
-      font-size: 2em;
-      line-height: 1.3em;
-      color: #666;
-      text-align: center;
-    }
-    .screenshot {
-      box-shadow: 0 0 30px rgba(0,0,0,0.2);
-      height: 382px;
-      max-width: 1276px;
-      margin: 2em auto;
-      background-image: url("images/action-shot.png");
-      background-repeat: no-repeat;
-      background-position: center left;
-      background-size: auto 100%;
-    }
-    /* Work around Safari's scaling-up of the screenshot on retina displays */
-    @media only screen and (-webkit-min-device-pixel-ratio: 2) {
-      .screenshot { height: 191px; max-width: 638px; }
-    }
-  </style>
 </head>
 <body>
 <div class="header">

--- a/releases.css
+++ b/releases.css
@@ -1,0 +1,33 @@
+article {
+    margin-bottom: 1em;
+}
+.release h2 {
+    display: inline-block;
+    font-size: 1em;
+}
+.date:before, .relnotes-link:before, .changelog-link:before {
+    content: "·";
+    margin-right: 0.3em;
+}
+.date, .relnotes-link, .changelog-link {
+    display: inline-block;
+    margin-left: 0.4em;
+}
+.download {
+    margin: 0.5em 0;
+    background-position: left top;
+    background-repeat: no-repeat;
+    padding-left: 74px;
+}
+.download.tarball {
+    background-image: url("../images/package.png");
+    min-height: 54px;
+}
+.download.patch {
+    background-image: url("../images/patch.png");
+    min-height: 64px;
+}
+.hash {
+    white-space: nowrap;
+    font-size: 0.9em;
+}

--- a/search.html
+++ b/search.html
@@ -29,17 +29,7 @@
   <div class="body_element">
     <div id="cse" style="width: 100%;">Loading</div>
     <script src="//www.google.com/jsapi" type="text/javascript"></script>
-    <script>
-     (function() {
-         var cx = '000379057217241479047:jjwkmhjefoc';
-         var gcse = document.createElement('script');
-         gcse.type = 'text/javascript';
-         gcse.async = true;
-         gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
-         var s = document.getElementsByTagName('script')[0];
-         s.parentNode.insertBefore(gcse, s);
-     })();
-    </script>
+    <script src="search.js" type="text/javascript"></script>
     <gcse:search></gcse:search>
   </div>
 </div>

--- a/search.js
+++ b/search.js
@@ -1,0 +1,9 @@
+(function() {
+    var cx = '000379057217241479047:jjwkmhjefoc';
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gcse, s);
+})();

--- a/style.css
+++ b/style.css
@@ -250,3 +250,40 @@ tt.download {
     font-weight: normal !important;
     font-family: inherit !important;
 }
+
+/* Page specific formatting */
+.slogan {
+    font-size: 2em;
+    line-height: 1.3em;
+    color: #666;
+    text-align: center;
+}
+.screenshot {
+    box-shadow: 0 0 30px rgba(0,0,0,0.2);
+    height: 382px;
+    max-width: 1276px;
+    margin: 2em auto;
+    background-image: url("images/action-shot.png");
+    background-repeat: no-repeat;
+    background-position: center left;
+    background-size: auto 100%;
+}
+/* Work around Safari's scaling-up of the screenshot on retina displays */
+@media only screen and (-webkit-min-device-pixel-ratio: 2) {
+    .screenshot { height: 191px; max-width: 638px; }
+}
+.repolink {
+    background-position: left top;
+    background-repeat: no-repeat;
+    padding-left: 74px;
+    background-image: url("images/package.png");
+    line-height: 54px;
+}
+.gpgkey {
+    margin: 0.5em 0;
+    background-position: left top;
+    background-repeat: no-repeat;
+    padding-left: 74px;
+    min-height: 64px;
+    background-image: url("../images/certificate.png");
+}


### PR DESCRIPTION
Moved inline style and script elements to files.
docs and dev-docs shouldn't have any inline scripts or styles.
Fix #22