### PR TITLE
Drop retired qpid package

### DIFF
--- a/yum-repos.conf
+++ b/yum-repos.conf
@@ -134,7 +134,6 @@ python-peak-util-symbols =
 # Previously shipped this from EPEL but it has moved into RHEL now:
 #python-prettytable =
 python-pydns =
-python-qpid = python2-qpid
 python-rdflib =
 python-requests-kerberos =
 python-epel-rpm-macros = python3-other-rpm-macros
@@ -172,7 +171,6 @@ python3-jinja2 = python34-jinja2 python36-jinja2
 python3-markupsafe = python34-markupsafe python36-markupsafe
 python3-Cython = python34-Cython python36-Cython
 python3-numpy = python34-numpy python36-numpy
-qpid-proton = qpid-proton-c python2-qpid-proton
 saslwrapper = saslwrapper python-saslwrapper
 scons = python2-scons
 TurboGears =


### PR DESCRIPTION
Partially cover the following issue: https://github.com/beaker-project/beaker/issues/80.
This will unblock yum generation for b-p.org. 