### PR TITLE
chore: use `$releasever` in RPM GPG key to download

### DIFF
--- a/yum/beaker-server-RedHatEnterpriseLinux.repo
+++ b/yum/beaker-server-RedHatEnterpriseLinux.repo
@@ -3,7 +3,7 @@ name=Beaker Server - RedHatEnterpriseLinux$releasever
 baseurl=https://beaker-project.org/yum/server/RedHatEnterpriseLinux$releasever/
 enabled=1
 gpgcheck=1
-gpgkey=https://beaker-project.org/gpg/RPM-GPG-KEY-redhatengsystems https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+gpgkey=https://beaker-project.org/gpg/RPM-GPG-KEY-redhatengsystems https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
 
 [beaker-server-testing]
 name=Beaker Server - RedHatEnterpriseLinux$releasever - Testing


### PR DESCRIPTION
Closes: #43